### PR TITLE
add event for msg.sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Tinlake Claim Rad Contract
 This contract allows a user to identify their ethereum address with a substrate key by submitting an `update()` transaction to the contract.
 
-Kovan Address: 0x18109F8cdf86597BBeA686CBDfd16e283bA164Dd
+Kovan Address: 0x297237e17F327f8e5C8dEd78b15761A7D513353b
 Mainnet Address: 0xb245D176E2aF3B37F28f42083bD2E0C64F48393d
 
 ## Example Usage
 
 ```
-seth send 0x18109F8cdf86597BBeA686CBDfd16e283bA164Dd 'update(bytes32)' 0xccad51ca5976118a5c9801e100f7a25cc6fbce87255a90221a492fd4c2833795
+seth send 0x297237e17F327f8e5C8dEd78b15761A7D513353b 'update(bytes32)' 0xccad51ca5976118a5c9801e100f7a25cc6fbce87255a90221a492fd4c2833795
 ```

--- a/src/claim.sol
+++ b/src/claim.sol
@@ -2,9 +2,11 @@ pragma solidity >=0.5.15;
 
 contract TinlakeClaimRAD {
     mapping (address => bytes32) public accounts;
+    event Claimed(address claimer, bytes32 account);
 
     function update(bytes32 account) public {
         require(account != 0);
         accounts[msg.sender] = account;
+        Claimed(msg.sender, account);
     }
 }


### PR DESCRIPTION
needed to put msg.sender in an event because The Graph only gives `from`

deployed on [kovan](https://kovan.etherscan.io/address/0x297237e17f327f8e5c8ded78b15761a7d513353b)